### PR TITLE
Change ingredient removal method to use index

### DIFF
--- a/src/app/ingredients/ingredients.component.html
+++ b/src/app/ingredients/ingredients.component.html
@@ -18,7 +18,7 @@
 >
   <ul class="space-y-2">
     <li
-      *ngFor="let ingredient of selectedIngredients"
+      *ngFor="let ingredient of selectedIngredients; let i = index"
       class="flex items-center justify-between"
     >
       <span>
@@ -27,7 +27,7 @@
       <button
         class="btn btn-outline-light text-white bg-orange-600 hover:bg-red-700 px-3 py-1 rounded"
         type="button"
-        (click)="removeIngredient(ingredient.id)"
+        (click)="removeIngredient(i)"
       >
         -
       </button>

--- a/src/app/ingredients/ingredients.component.ts
+++ b/src/app/ingredients/ingredients.component.ts
@@ -70,10 +70,9 @@ export class IngredientsComponent implements OnInit {
     return 'N/A';
   }
 
-  removeIngredient(id: number) {
-    this.ingredientService.removeIngredient(id);
+  removeIngredient(index : number) {
+    this.ingredientService.removeIngredientByIndex(index);
     this.calculateTotalCarbs();
-    location.reload();
   }
 
   calculateTotalCarbs() {

--- a/src/app/shared/ingredient.service.ts
+++ b/src/app/shared/ingredient.service.ts
@@ -84,25 +84,15 @@ export class IngredientService {
     return this.selectedIngredients;
   }
 
-  // Remove an ingredient and save to localStorage
-  removeIngredient(id: number) {
-    if (this.carbs.length != 1) {
-      delete this.carbs[
-        this.selectedIngredients.findIndex((ingredient) => ingredient.id === id)
-      ];
-      delete this.amount[
-        this.selectedIngredients.findIndex((ingredient) => ingredient.id === id)
-      ];
-      this.carbs = this.carbs.filter((e) => e != null);
-      this.amount = this.amount.filter((e) => e != null);
-    } else {
-      this.carbs = [];
-      this.amount = [];
+  // Remove an ingredient by index
+  removeIngredientByIndex(index: number) {
+    if (index >= 0 && index < this.selectedIngredients.length) {
+      // Remove the ingredient, carbs, and amount at the same index
+      this.selectedIngredients.splice(index, 1);
+      this.carbs.splice(index, 1);
+      this.amount.splice(index, 1);
+      this.saveToLocalStorage();
     }
-    this.selectedIngredients = this.selectedIngredients.filter(
-      (ingredient) => ingredient.id !== id
-    );
-    this.saveToLocalStorage();
   }
 
   // Calculate total carbs


### PR DESCRIPTION
Update the ingredient removal method to eliminate the need for page reloads by removing items based on their index instead of their ID.